### PR TITLE
fix(Android:GiphyDialog): GIPHY rating does not work when using GiphyDialog.configure to specify it

### DIFF
--- a/android/src/main/java/com/giphyreactnativesdk/GiphySettings.kt
+++ b/android/src/main/java/com/giphyreactnativesdk/GiphySettings.kt
@@ -30,16 +30,16 @@ private fun capitalize(word: String): String {
 }
 
 fun snakeToCamel(value: String?): String? {
-  return when(value) {
+  return when (value) {
     null -> null
-    else -> value.split("_").mapIndexed {
-        idx, word -> if(idx == 0) word.lowercase() else capitalize(word)
+    else -> value.split("_").mapIndexed { idx, word ->
+      if (idx == 0) word.lowercase() else capitalize(word)
     }.joinToString("")
   }
 }
 
 fun renditionByName(renditionName: String?): RenditionType? {
-  return when(renditionName) {
+  return when (renditionName) {
     null -> null
     else -> RenditionType.values().firstOrNull { it.name == snakeToCamel(renditionName) }
   }
@@ -57,7 +57,7 @@ fun gphRatingByName(ratingName: String?): RatingType? {
 }
 
 fun getContentType(contentType: String?): GPHContentType {
-  return when(contentType) {
+  return when (contentType) {
     null -> GPHContentType.gif
     else -> GPHContentType.values().firstOrNull { it.name == contentType.lowercase() }
       ?: GPHContentType.gif
@@ -84,7 +84,8 @@ fun giphySettingsFromReadableMap(
   }
 
   if (options.hasKey(RNSettings.rating.toString())) {
-    settings.rating = gphRatingByName(RNSettings.rating.toString()) ?: RatingType.pg13
+    val rawRating = options.getString(RNSettings.rating.toString())
+    settings.rating = gphRatingByName(rawRating) ?: RatingType.pg13
   }
 
   if (options.hasKey(RNSettings.showConfirmationScreen.toString())) {
@@ -104,9 +105,10 @@ fun giphySettingsFromReadableMap(
   }
 
   if (options.hasKey(RNSettings.mediaTypeConfig.toString())) {
-    val typeConfig = options.getArray(RNSettings.mediaTypeConfig.toString())?.toArrayList()?.map {
-        ctype -> getContentType(ctype.toString())
-    }?.toTypedArray()
+    val typeConfig =
+      options.getArray(RNSettings.mediaTypeConfig.toString())?.toArrayList()?.map { ctype ->
+        getContentType(ctype.toString())
+      }?.toTypedArray()
 
     if (typeConfig != null) {
       settings.mediaTypeConfig = typeConfig

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -361,13 +361,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   Giphy: 6757d929878ef45f70ed62a02a2c9a03994e7b6c
   giphy-react-native-sdk: fa0f3b49314c1d78c47d447393abc9e1cee03e0e
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   libwebp: 98a37e597e40bfdb4c911fc98f2c53d0b12d05fc
   RCTRequired: 082f10cd3f905d6c124597fd1c14f6f2655ff65e
   RCTTypeSafety: 8c9c544ecbf20337d069e4ae7fd9a377aadf504b

--- a/package.json
+++ b/package.json
@@ -103,7 +103,11 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "header-max-length": [1, "always", 100],
+      "subject-case": [0, "always", "pascal-case"]
+    }
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
Changes:
- fix(Android:GiphyDialog): GIPHY rating does not work when using `GiphyDialog.configure` to specify it
