### PR TITLE
fix: TypeScript definitions are placed in the wrong folder

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "e2e"]
 }


### PR DESCRIPTION
re #80